### PR TITLE
Added mute feature

### DIFF
--- a/Kappa Everywhere/contentscript.js
+++ b/Kappa Everywhere/contentscript.js
@@ -7,6 +7,7 @@ kappa = false;
 globals = true;
 subs = true;
 bttv = false;
+mute = false;
 filter_text = '';
 filter_list = [];
 site_filter_text = '';
@@ -20,6 +21,7 @@ chrome.storage.sync.get({
     globals: true,
     subs: true,
 	bttv: false,
+    mute: false,
 	filter_text: '',
 	site_filter_text: '',
 },function(items) {
@@ -27,6 +29,7 @@ chrome.storage.sync.get({
     globals = items.globals;
     subs = items.subs;
 	bttv = items.bttv;
+    mute = items.mute;
 
     filter_text = items.filter_text;
     filter_list = filter_text.split(/[\.,\s]+/);
@@ -48,6 +51,7 @@ loaded1 = false;
 loaded2 = false;
 loaded3 = false;
 loaded4 = false;
+loaded5 = false;
 
 function replace_words() {
     // "If there's no cached data" "or the data is a week old" "or if i goddamn tell you to remotely"
@@ -371,7 +375,9 @@ function replace_text(element) {
 
                 txt = document.createTextNode(buffer);
                 parent_element.insertBefore(txt, element);
-                parent_element.insertBefore(img, element);
+                if (!mute) {
+                    parent_element.insertBefore(img, element);
+                }
                 buffer = '';
             } else {
                 buffer += word;

--- a/Kappa Everywhere/options.html
+++ b/Kappa Everywhere/options.html
@@ -28,13 +28,16 @@
         </div>
 		
         <label><input id="globals" type="checkbox" name="options" checked>Enable global emotes</label> 
-        <br>
+        <br />
 
         <label><input id="subs" type="checkbox" name="options" checked>Enable sub emotes</label> 
-		<br>
+		<br />
 		
 		<label><input id="bttv" type="checkbox" name="options">Enable Better TTV emotes</label> 
-		<br>
+		<br />
+
+        <label><input id="mute" type="checkbox" name="options">Mute enabled emotes</label> 
+        <br />
 		
         </form>
     </div>
@@ -52,7 +55,7 @@
     <textarea id="site_filter" style="width:300px; height:150px;">
     </textarea>
 
-    <br>
+    <br />
 
     <!-- footer, begging, whatnot -->
     <div id="saved" style="display:none; font-size:100%; color:#ff0000;">Saved!</div>

--- a/Kappa Everywhere/options.js
+++ b/Kappa Everywhere/options.js
@@ -9,6 +9,7 @@ var idlist = [
     'subs',
     'kappa',
 	'bttv',
+    'mute'
 ];
 
 // startup stuff
@@ -40,6 +41,7 @@ function save_options() {
     var globals = document.getElementById('globals');
     var subs = document.getElementById('subs');
 	var bttv = document.getElementById('bttv');
+    var mute = document.getElementById('mute');
 
     var sub_filter = document.getElementById('sub_filter');
     var filter_text = sub_filter.value;
@@ -52,6 +54,7 @@ function save_options() {
         globals: globals.checked,
         subs: subs.checked,
 		bttv: bttv.checked,
+        mute: mute.checked,
         filter_text: filter_text,
         site_filter_text: site_filter_text,
     }, function() {
@@ -70,6 +73,7 @@ function restore_options() {
       globals: true,
       subs: true,
 	  bttv: false,
+      mute: false,
       filter_text: '',
       site_filter_text: '',
   }, function(items) {
@@ -77,6 +81,7 @@ function restore_options() {
       document.getElementById('globals').checked = items.globals;
       document.getElementById('subs').checked = items.subs;
 	  document.getElementById('bttv').checked = items.bttv;
+      document.getElementById('mute').checked = items.mute;
       document.getElementById('sub_filter').value = items.filter_text;
       document.getElementById('site_filter').value = items.site_filter_text;
   });


### PR DESCRIPTION
I’ve added a mute enabled emotes option to the extension.  For those who don’t want to see the text or emotes.

Doesn’t quite work well for emotes between words, i.e. “Hello BibleThump Hello” will lead to an extra space between the “Hello”s.